### PR TITLE
[@replit/clui-session] Added default export of Session

### DIFF
--- a/packages/clui-session/src/index.tsx
+++ b/packages/clui-session/src/index.tsx
@@ -1,5 +1,6 @@
 export {
   default as Session,
+  default,
   ISession,
   ISessionItem,
   ISessionItemProps,


### PR DESCRIPTION
These are used interchangeably in the docs/example repl:

```
import Session, { Do } from '@replit/clui-session';
```

```
import { Session } from '@replit/clui-session';
```

The former breaks since Session isn't a default export.

### Test:

* `yarn run build`
* `node`
* `> require(.)` now contains `default`