### PR TITLE
add includeExactMatch option

### DIFF
--- a/packages/clui-input/package.json
+++ b/packages/clui-input/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@replit/clui-input",
-  "version": "0.0.12",
+  "version": "0.0.13",
   "description": "A utility library for building CLI style interfaces with autocomplete",
   "main": "dist/index.js",
   "files": [

--- a/packages/clui-input/package.json
+++ b/packages/clui-input/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@replit/clui-input",
-  "version": "0.0.13",
+  "version": "0.0.14",
   "description": "A utility library for building CLI style interfaces with autocomplete",
   "main": "dist/index.js",
   "files": [

--- a/packages/clui-input/src/__tests__/input.test.ts
+++ b/packages/clui-input/src/__tests__/input.test.ts
@@ -38,6 +38,127 @@ describe('no input', () => {
   });
 });
 
+describe('includeExactMatch', () => {
+  it('includes exact command match', (done) => {
+    const root: ICommand = {
+      commands: {
+        user: {
+          commands: { add: {} },
+        },
+      },
+    };
+
+    createInput({
+      includeExactMatch: true,
+      command: root,
+      value: 'user',
+      index: 'user'.length,
+      onUpdate: (updates) => {
+        expect(updates.options).toEqual([
+          {
+            value: 'user ',
+            data: { commands: { add: {} } },
+            inputValue: 'user ',
+            cursorTarget: 'user '.length,
+          },
+        ]);
+        done();
+      },
+    });
+  });
+
+  it('includes exact sub-command match', (done) => {
+    const root: ICommand = {
+      commands: {
+        user: {
+          commands: { add: {} },
+        },
+      },
+    };
+
+    createInput({
+      includeExactMatch: true,
+      command: root,
+      value: 'user add',
+      index: 'user add'.length,
+      onUpdate: (updates) => {
+        expect(updates.options).toEqual([
+          {
+            value: 'add ',
+            data: {},
+            inputValue: 'user add ',
+            cursorTarget: 'user add '.length,
+          },
+        ]);
+        done();
+      },
+    });
+  });
+
+  it('includes exact arg key match', (done) => {
+    const root: ICommand = {
+      commands: {
+        user: {
+          args: {
+            id: {},
+          },
+          commands: { add: {} },
+        },
+      },
+    };
+
+    createInput({
+      includeExactMatch: true,
+      command: root,
+      value: 'user --id',
+      index: 'user --id'.length,
+      onUpdate: (updates) => {
+        expect(updates.options).toEqual([
+          {
+            value: '--id ',
+            data: {},
+            inputValue: 'user --id ',
+            cursorTarget: 'user --id '.length,
+          },
+        ]);
+        done();
+      },
+    });
+  });
+
+  it('includes exact arg flag match', (done) => {
+    const root: ICommand = {
+      commands: {
+        user: {
+          args: {
+            id: {
+              type: 'boolean',
+            },
+          },
+        },
+      },
+    };
+
+    createInput({
+      includeExactMatch: true,
+      command: root,
+      value: 'user --id',
+      index: 'user --id'.length,
+      onUpdate: (updates) => {
+        expect(updates.options).toEqual([
+          {
+            value: '--id ',
+            data: { type: 'boolean' },
+            inputValue: 'user --id ',
+            cursorTarget: 'user --id '.length,
+          },
+        ]);
+        done();
+      },
+    });
+  });
+});
+
 describe('previousNode', () => {
   it('suggests commands', (done) => {
     const root: ICommand = { commands: { user: { commands: { add: {} } } } };

--- a/packages/clui-input/src/__tests__/input.test.ts
+++ b/packages/clui-input/src/__tests__/input.test.ts
@@ -157,6 +157,37 @@ describe('includeExactMatch', () => {
       },
     });
   });
+
+  it('searches when there is no exact match', (done) => {
+    const root: ICommand = {
+      commands: {
+        user: {
+          commands: {
+            add: {},
+          },
+        },
+      },
+    };
+
+    createInput({
+      includeExactMatch: true,
+      command: root,
+      value: 'use',
+      index: 'use'.length,
+      onUpdate: (updates) => {
+        expect(updates.options).toEqual([
+          {
+            value: 'user',
+            data: { commands: { add: {} } },
+            inputValue: 'user',
+            searchValue: 'use',
+            cursorTarget: 'user'.length,
+          },
+        ]);
+        done();
+      },
+    });
+  });
 });
 
 describe('previousNode', () => {

--- a/packages/clui-input/src/input.ts
+++ b/packages/clui-input/src/input.ts
@@ -24,6 +24,7 @@ export interface IInputUpdates<D = any, R = any> {
 
 export interface IConfig<C extends ICommand = ICommand> {
   searchFn?: SearchFn;
+  includeExactMatch?: boolean;
   onUpdate: (updates: IInputUpdates) => void;
   command: C;
   value?: string;
@@ -130,6 +131,7 @@ export const createInput = (config: IConfig) => {
     };
 
     const getOptions = optionsProvider({
+      includeExactMatch: config.includeExactMatch,
       command: config.command,
       commandsCache,
       optionsCache,

--- a/packages/clui-input/src/options.ts
+++ b/packages/clui-input/src/options.ts
@@ -476,12 +476,14 @@ export const optionsProvider = (config: IConfig) => (
         data = previousNode.parent.ref;
       }
 
-      options.push({
-        cursorTarget: inputValue.length,
-        value,
-        inputValue,
-        data,
-      });
+      if (data) {
+        options.push({
+          cursorTarget: inputValue.length,
+          value,
+          inputValue,
+          data,
+        });
+      }
     }
 
     options.push(

--- a/packages/clui-input/src/options.ts
+++ b/packages/clui-input/src/options.ts
@@ -3,6 +3,7 @@ import { ASTNodeKind, ASTNode } from './ast';
 import { ICommands, ICommand, IArgsOption, SearchFn, IOption } from './types';
 
 interface IConfig {
+  includeExactMatch?: boolean;
   command: ICommand;
   commandsCache: Record<string, ICommands>;
   optionsCache: Record<string, Array<IArgsOption>>;
@@ -412,11 +413,7 @@ const NodeTypes: Record<ASTNodeKind, OptionsFn> = {
     return options;
   },
 
-  PENDING: (params) => {
-    console.log(params);
-
-    return [];
-  },
+  PENDING: (__params) => [],
 };
 
 export const optionsProvider = (config: IConfig) => (
@@ -460,10 +457,41 @@ export const optionsProvider = (config: IConfig) => (
       ? params.value.slice(nodeStart, params.index).trim()
       : undefined;
 
-    return NodeTypes[params.previousNode.kind](
-      { valueStart, nodeStart, search, atWhitespace, ...params },
-      config,
+    const options: Options = [];
+
+    if (
+      config.includeExactMatch &&
+      'token' in params.previousNode &&
+      params.previousNode.token.value === search
+    ) {
+      const { previousNode } = params;
+      const value = `${previousNode.token.value} `;
+      const inputValue = params.value.slice(0, nodeStart) + value;
+
+      let data: any;
+
+      if ('ref' in previousNode) {
+        data = previousNode.ref;
+      } else if ('parent' in previousNode) {
+        data = previousNode.parent.ref;
+      }
+
+      options.push({
+        cursorTarget: inputValue.length,
+        value,
+        inputValue,
+        data,
+      });
+    }
+
+    options.push(
+      ...NodeTypes[params.previousNode.kind](
+        { valueStart, nodeStart, search, atWhitespace, ...params },
+        config,
+      ),
     );
+
+    return options;
   }
 
   return [];


### PR DESCRIPTION
This adds an option to include the exact match in the suggested options. The tests should cover behavior. 

