### PR TITLE
add command.options function

### DIFF
--- a/packages/clui-input/src/__tests__/input.options.test.ts
+++ b/packages/clui-input/src/__tests__/input.options.test.ts
@@ -1,4 +1,3 @@
-// @ts-nocheck
 import { ICommand } from '../types';
 import { createInput } from '../input';
 
@@ -7,7 +6,7 @@ const options = [{ value: 'foo bar' }];
 const root: ICommand = {
   commands: {
     search: {
-      options: async (__search?: string) => options,
+      options: async (__search?: string) => Promise.resolve(options),
       commands: {
         foo: {},
       },

--- a/packages/clui-input/src/__tests__/input.options.test.ts
+++ b/packages/clui-input/src/__tests__/input.options.test.ts
@@ -1,0 +1,78 @@
+// @ts-nocheck
+import { ICommand } from '../types';
+import { createInput } from '../input';
+
+const options = [{ value: 'foo bar' }];
+
+const root: ICommand = {
+  commands: {
+    search: {
+      options: async (__search?: string) => options,
+      commands: {
+        foo: {},
+      },
+    },
+  },
+};
+
+it('suggests options', (done) => {
+  createInput({
+    command: root,
+    value: 'search foob',
+    index: 'search foob'.length,
+    includeExactMatch: true,
+    onUpdate: (updates) => {
+      expect(updates.options).toEqual([
+        {
+          value: 'foo bar',
+          searchValue: 'foob',
+          data: { value: 'foo bar' },
+          inputValue: 'search foo bar',
+          cursorTarget: 'search foo bar'.length,
+        },
+      ]);
+      done();
+    },
+  });
+});
+
+it('suggests commands and options', (done) => {
+  createInput({
+    command: root,
+    value: 'search fo',
+    index: 'search fo'.length,
+    includeExactMatch: true,
+    onUpdate: (updates) => {
+      expect(updates.options).toEqual([
+        {
+          value: 'foo bar',
+          searchValue: 'fo',
+          data: { value: 'foo bar' },
+          inputValue: 'search foo bar',
+          cursorTarget: 'search foo bar'.length,
+        },
+        {
+          value: 'foo',
+          searchValue: 'fo',
+          data: {},
+          inputValue: 'search foo',
+          cursorTarget: 'search foo'.length,
+        },
+      ]);
+      done();
+    },
+  });
+});
+
+it('does not suggest options when a command is matched', (done) => {
+  createInput({
+    command: root,
+    value: 'search foo b',
+    index: 'search foo b'.length,
+    includeExactMatch: true,
+    onUpdate: (updates) => {
+      expect(updates.options).toEqual([]);
+      done();
+    },
+  });
+});

--- a/packages/clui-input/src/types.ts
+++ b/packages/clui-input/src/types.ts
@@ -53,9 +53,14 @@ type Thunk<V> = V | ThunkFn<V>;
 
 type RunFn<O, R> = (options: IRunOptions<O>) => R;
 
+interface IOptionResult {
+  value: string;
+}
+
 export interface ICommand<O = any, R = any> {
   args?: ICommandArgs;
   commands?: Thunk<ICommands<ICommand>>;
+  options?: <D extends IOptionResult>(search?: string) => Promise<Array<D>>;
   run?: RunFn<O, R>;
 }
 

--- a/packages/clui-input/src/types.ts
+++ b/packages/clui-input/src/types.ts
@@ -53,14 +53,10 @@ type Thunk<V> = V | ThunkFn<V>;
 
 type RunFn<O, R> = (options: IRunOptions<O>) => R;
 
-interface IOptionResult {
-  value: string;
-}
-
 export interface ICommand<O = any, R = any> {
   args?: ICommandArgs;
   commands?: Thunk<ICommands<ICommand>>;
-  options?: <D extends IOptionResult>(search?: string) => Promise<Array<D>>;
+  options?: (search?: string) => Promise<Array<{ value: string }>>;
   run?: RunFn<O, R>;
 }
 


### PR DESCRIPTION
adds a way to return command options based on the remaining string. use full is you have `search` command and want to support a command like "search foo bar" where "foo bar" is the string you want to search by.

`input.options.test.ts` shows how this works with potential sub-commands.
