### PR TITLE
add support for root options function

### DIFF
--- a/packages/clui-input/src/__tests__/input.options.test.ts
+++ b/packages/clui-input/src/__tests__/input.options.test.ts
@@ -1,105 +1,157 @@
 import { ICommand } from '../types';
 import { createInput } from '../input';
 
-const options = [{ value: 'foo bar' }];
+describe('root command options', () => {
+  const root: ICommand = {
+    options() {
+      return Promise.resolve([{ value: 'ab' }]);
+    },
+  };
 
-const root: ICommand = {
-  commands: {
-    search: {
-      options: async (__search?: string) => Promise.resolve(options),
-      commands: {
-        foo: {},
+  it('suggests options', (done) => {
+    createInput({
+      command: root,
+      value: '',
+      index: ''.length,
+      onUpdate: (updates) => {
+        expect(updates.options).toEqual([
+          {
+            value: 'ab',
+            data: {
+              value: 'ab',
+            },
+            inputValue: 'ab',
+            cursorTarget: 'ab'.length,
+          },
+        ]);
+        done();
+      },
+    });
+  });
+
+  it('filters options', (done) => {
+    createInput({
+      command: root,
+      value: 'a',
+      index: 'a'.length,
+      onUpdate: (updates) => {
+        expect(updates.options).toEqual([
+          {
+            value: 'ab',
+            data: {
+              value: 'ab',
+            },
+            inputValue: 'ab',
+            cursorTarget: 'ab'.length,
+          },
+        ]);
+        done();
+      },
+    });
+  });
+});
+
+describe('command options', () => {
+  const options = [{ value: 'foo bar' }];
+
+  const root: ICommand = {
+    commands: {
+      search: {
+        options: async (__search?: string) => Promise.resolve(options),
+        commands: {
+          foo: {},
+        },
       },
     },
-  },
-};
+  };
 
-it('suggests commands and options without search', (done) => {
-  createInput({
-    command: root,
-    value: 'search ',
-    index: 'search '.length,
-    includeExactMatch: true,
-    onUpdate: (updates) => {
-      expect(updates.options).toEqual([
-        {
-          value: 'foo bar',
-          searchValue: undefined,
-          data: { value: 'foo bar' },
-          inputValue: 'search foo bar',
-          cursorTarget: 'search foo bar'.length,
-        },
-        {
-          value: 'foo',
-          searchValue: undefined,
-          data: {},
-          inputValue: 'search foo',
-          cursorTarget: 'search foo'.length,
-        },
-      ]);
-      done();
-    },
+  it('suggests commands and options without search', (done) => {
+    createInput({
+      command: root,
+      value: 'search ',
+      index: 'search '.length,
+      includeExactMatch: true,
+      onUpdate: (updates) => {
+        expect(updates.options).toEqual([
+          {
+            value: 'foo bar',
+            searchValue: undefined,
+            data: { value: 'foo bar' },
+            inputValue: 'search foo bar',
+            cursorTarget: 'search foo bar'.length,
+          },
+          {
+            value: 'foo',
+            searchValue: undefined,
+            data: {},
+            inputValue: 'search foo',
+            cursorTarget: 'search foo'.length,
+          },
+        ]);
+        done();
+      },
+    });
   });
-});
 
-it('suggests options', (done) => {
-  createInput({
-    command: root,
-    value: 'search foob',
-    index: 'search foob'.length,
-    includeExactMatch: true,
-    onUpdate: (updates) => {
-      expect(updates.options).toEqual([
-        {
-          value: 'foo bar',
-          searchValue: 'foob',
-          data: { value: 'foo bar' },
-          inputValue: 'search foo bar',
-          cursorTarget: 'search foo bar'.length,
-        },
-      ]);
-      done();
-    },
+  it('suggests options', (done) => {
+    createInput({
+      command: root,
+      value: 'search foob',
+      index: 'search foob'.length,
+      includeExactMatch: true,
+      onUpdate: (updates) => {
+        expect(updates.options).toEqual([
+          {
+            value: 'foo bar',
+            searchValue: 'foob',
+            data: { value: 'foo bar' },
+            inputValue: 'search foo bar',
+            cursorTarget: 'search foo bar'.length,
+          },
+        ]);
+        done();
+      },
+    });
   });
-});
 
-it('suggests commands and options', (done) => {
-  createInput({
-    command: root,
-    value: 'search fo',
-    index: 'search fo'.length,
-    includeExactMatch: true,
-    onUpdate: (updates) => {
-      expect(updates.options).toEqual([
-        {
-          value: 'foo bar',
-          searchValue: 'fo',
-          data: { value: 'foo bar' },
-          inputValue: 'search foo bar',
-          cursorTarget: 'search foo bar'.length,
-        },
-        {
-          value: 'foo',
-          searchValue: 'fo',
-          data: {},
-          inputValue: 'search foo',
-          cursorTarget: 'search foo'.length,
-        },
-      ]);
-      done();
-    },
+  it('suggests commands and options', (done) => {
+    createInput({
+      command: root,
+      value: 'search fo',
+      index: 'search fo'.length,
+      includeExactMatch: true,
+      onUpdate: (updates) => {
+        expect(updates.options).toEqual([
+          {
+            value: 'foo bar',
+            searchValue: 'fo',
+            data: { value: 'foo bar' },
+            inputValue: 'search foo bar',
+            cursorTarget: 'search foo bar'.length,
+          },
+          {
+            value: 'foo',
+            searchValue: 'fo',
+            data: {},
+            inputValue: 'search foo',
+            cursorTarget: 'search foo'.length,
+          },
+        ]);
+        done();
+      },
+    });
   });
-});
 
-it('does not suggest options when a command is matched', (done) => {
-  createInput({
-    command: root,
-    value: 'search foo b',
-    index: 'search foo b'.length,
-    includeExactMatch: true,
-    onUpdate: (updates) => {
-      expect(updates.options).toEqual([]);
-      done();
-    },
+  it('does not suggest options when a command is matched', (done) => {
+    createInput({
+      command: root,
+      value: 'search foo b',
+      index: 'search foo b'.length,
+      includeExactMatch: true,
+      onUpdate: (updates) => {
+        expect(updates.options).toEqual([]);
+        done();
+      },
+    });
   });
 });

--- a/packages/clui-input/src/input.ts
+++ b/packages/clui-input/src/input.ts
@@ -139,6 +139,29 @@ export const createInput = (config: IConfig) => {
     });
 
     if (!value) {
+      if (typeof config.command.options === 'function') {
+        const optionsFn = config.command.options;
+        const results = await optionsFn();
+
+        if (current !== updatedAt) {
+          // Bail if an update happened before this function completes
+          return;
+        }
+
+        options.push(
+          ...results.map((result) => {
+            const inputValue = result.value;
+
+            return {
+              value: result.value,
+              inputValue,
+              cursorTarget: inputValue.length,
+              data: result,
+            };
+          }),
+        );
+      }
+
       // Handle top-level options when there is no input value
       let rootCommands: ICommands | null = commandsCache[''] || null;
 
@@ -244,7 +267,10 @@ export const createInput = (config: IConfig) => {
 
           options.push(
             ...results.map((result) => {
-              const inputValue = `${prefix} ${result.value}`;
+              const inputValue =
+                previousNode.token.start === 0
+                  ? result.value
+                  : `${prefix} ${result.value}`;
 
               return {
                 value: result.value,


### PR DESCRIPTION
The `options` function is only working when used on a sub-command (ie `search ...`). this adds support for root `options` function. Also added a test to cover this case. 

