### PR TITLE
fix missing query string in root options function

### DIFF
--- a/packages/clui-input/src/__tests__/input.options.test.ts
+++ b/packages/clui-input/src/__tests__/input.options.test.ts
@@ -37,6 +37,7 @@ describe('root command options', () => {
       onUpdate: (updates) => {
         expect(updates.options).toEqual([
           {
+            searchValue: 'a',
             value: 'ab',
             data: {
               value: 'ab',

--- a/packages/clui-input/src/input.ts
+++ b/packages/clui-input/src/input.ts
@@ -366,9 +366,8 @@ export const createInput = (config: IConfig) => {
            * ```
            */
           const optionsFn = previousNode.ref.options;
-          const { token } = previousNode;
-          const prefix = ast.source.slice(0, token.end);
-          const suffix = ast.source.slice(token.end);
+          const prefix = ast.source.slice(0, nodeStart - 1);
+          const suffix = ast.source.slice(nodeStart);
           const searchValue = suffix.trimLeft() || undefined;
           // TODO cache like commands/arg options?
           const results = await optionsFn(searchValue);
@@ -415,9 +414,8 @@ export const createInput = (config: IConfig) => {
            * ```
            */
           const optionsFn = previousNode.cmdNodeCtx.ref.options;
-          const { token } = previousNode.cmdNodeCtx;
-          const prefix = ast.source.slice(0, token.end);
-          const suffix = ast.source.slice(token.end);
+          const prefix = ast.source.slice(0, nodeStart - 1);
+          const suffix = ast.source.slice(nodeStart);
           const searchValue = suffix.trimLeft() || undefined;
           const results = await optionsFn(searchValue);
 


### PR DESCRIPTION
the string to filter by is not being passed to the options` function correctly for the root command. 

this adds the missing test case and fixes the logic

```ts
// for input: "a"

cont rootCommand = {
  options: (q?: string) => { 
     // q === "a" (currently this is incorreclty `undefined`)
  }
}
```