### PR TITLE
fix for options returning incorrectly when command is matched exactly

### DIFF
--- a/packages/clui-input/src/__tests__/input.options.test.ts
+++ b/packages/clui-input/src/__tests__/input.options.test.ts
@@ -55,14 +55,16 @@ describe('root command options', () => {
 describe('command options', () => {
   const options = [{ value: 'foo bar' }];
 
+  const search = {
+    options: async (__search?: string) => Promise.resolve(options),
+    commands: {
+      foo: {},
+    },
+  };
+
   const root: ICommand = {
     commands: {
-      search: {
-        options: async (__search?: string) => Promise.resolve(options),
-        commands: {
-          foo: {},
-        },
-      },
+      search,
     },
   };
 
@@ -143,7 +145,27 @@ describe('command options', () => {
     });
   });
 
-  it('does not suggest options when a command is matched', (done) => {
+  it('does not suggest options when a command is matched exactly', (done) => {
+    createInput({
+      command: root,
+      value: 'search',
+      index: 'search'.length,
+      includeExactMatch: true,
+      onUpdate: (updates) => {
+        expect(updates.options).toEqual([
+          {
+            value: 'search ',
+            data: search,
+            inputValue: 'search ',
+            cursorTarget: 'search '.length,
+          },
+        ]);
+        done();
+      },
+    });
+  });
+
+  it('does not suggest options after a command is matched', (done) => {
     createInput({
       command: root,
       value: 'search foo b',

--- a/packages/clui-input/src/input.ts
+++ b/packages/clui-input/src/input.ts
@@ -346,6 +346,7 @@ export const createInput = (config: IConfig) => {
         // Cursor is at the end of the input. Get options based on the previous node
         if (
           previousNode.kind === 'COMMAND' &&
+          index > previousNode.token.end &&
           typeof previousNode?.ref.options === 'function'
         ) {
           /*


### PR DESCRIPTION
options of a sub commends are being returned to early. options should only be returned once you hit space after a matched command (i.e.  "search " not "search" ). this adds a test and fix for this case by checking if that index is after the end of the matched command.