### PR TITLE
Bump `@replit/clui-gql` to 0.0.8

### DIFF
--- a/packages/clui-gql/package.json
+++ b/packages/clui-gql/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@replit/clui-gql",
-  "version": "0.0.7",
+  "version": "0.0.8",
   "private": true,
   "description": "A utility to transform GraphQL introspection type into a CLUI command",
   "scripts": {


### PR DESCRIPTION
Bump package version for `clui-gql` so we can publish a new version with this bugfix https://github.com/replit/clui/pull/43