### PR TITLE
Add deprecated notice to readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # CLUI
 
+**This repository is no longer maintained** 
+
 CLUI is a collection of JavaScript libraries for building command-line interfaces with context-aware autocomplete.
 
 [See Demo](https://repl.it/@clui/demo)


### PR DESCRIPTION
We no longer maintain this, so we should add that to the README. 